### PR TITLE
Unused type warning

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,6 +35,8 @@
     :with-test
     (>= v0.17)
     (< v0.18)))
+  (ppxlib
+   (>= 0.32.2-preview.1))
   (ppx_expect
    (and
     :with-test

--- a/letfun.opam
+++ b/letfun.opam
@@ -13,6 +13,7 @@ depends: [
   "base" {with-test & >= "v0.17" & < "v0.18"}
   "bisect_ppx" {dev & >= "2.8.3"}
   "expect-test-helpers" {with-test & >= "v0.17" & < "v0.18"}
+  "ppxlib" {>= "0.32.2-preview.1"}
   "ppx_expect" {with-test & >= "v0.17" & < "v0.18"}
   "ppx_js_style" {dev & >= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {with-test & >= "v0.17" & < "v0.18"}

--- a/test/dune
+++ b/test/dune
@@ -19,4 +19,4 @@
  (lint
   (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
-  (pps ppx_expect ppx_sexp_value)))
+  (pps -unused-type-warnings=true ppx_expect ppx_sexp_value)))


### PR DESCRIPTION
This is an experimental PR to test the change made in https://github.com/ocaml-ppx/ppxlib/pull/493

This is using an unreleased preview packages that combines ongoing changes from ppxlib, published [here](https://github.com/mbarbin/ppxlib/releases/tag/0.32.2-preview.1)

In this repo, I don't actually need this option, rather I am creating this PR to show an live example of what happens if you supply the flag to a combination of ppx that are apparently not packaged into a standard driver. The flag is not known by the driver in use here, and thus the build fails.

I don't know yet what to think about it. On one hand I can understand that this doesn't make sense to try and supply flags if they are not going to impact the executions of said ppx, on the other hand, this makes adding the flag systematically across a code base more challenging.